### PR TITLE
Give registers meaningful names

### DIFF
--- a/lz4depack.asm
+++ b/lz4depack.asm
@@ -29,9 +29,9 @@ depack:
    addi a0, a0 ,2
    add a3, a2, a0       #current pos+size=end
 fetch_token:
-   lbu a4, 0(a0)
+   lbu a7, 0(a0)
    addi a0, a0, 1
-   srli a5, a4, 4       #a5 = literal length
+   srli a5, a7, 4       #a5 = literal length
    beqz a5, fetch_offset
    jal fetch_length
 
@@ -40,13 +40,13 @@ fetch_token:
    mv a0, a2
 
 fetch_offset:
-   lbu s1, 0(a0)        #offset is halfword but at byte alignment
-   sub a2, a1, s1
-   lbu s1, 1(a0)
+   lbu a4, 0(a0)        #offset is halfword but at byte alignment
+   sub a2, a1, a4
+   lbu a4, 1(a0)
    addi a0, a0, 2       #placed here for pipeline
-   slli s1, s1, 8
-   sub a2, a2, s1 
-   andi a5, a4, 0x0f    #get offset
+   slli a4, a4, 8
+   sub a2, a2, a4
+   andi a5, a7, 0x0f    #get offset
    jal fetch_length
    addi a5, a5, 4       #match length is >4 bytes
    jal copy_data
@@ -56,15 +56,15 @@ fetch_offset:
    ret
 
 fetch_length:
-   xori s1, a5, 0xf
-   bnez s1, _done       #0x0f indicates further bytes
+   xori a4, a5, 0xf
+   bnez a4, _done       #0x0f indicates further bytes
 
 _loop:   
-   lbu s1, 0(a0)
+   lbu a4, 0(a0)
    addi a0, a0, 1
-   add a5, a5, s1
-   xori s1, s1, 0xff    #0xff indicates further bytes
-   beqz s1, _loop
+   add a5, a5, a4
+   xori a4, a4, 0xff    #0xff indicates further bytes
+   beqz a4, _loop
 _done:
    ret
 

--- a/lz4depack.asm
+++ b/lz4depack.asm
@@ -23,8 +23,7 @@ depack:
    #    a1 is destination
    #used: a1,a2,a3,a4,a5,a6 for compliance with C-extension
    
-   addi	sp,sp,-16
-   sw	ra, 0(sp)
+   mv t0, ra
    lhu a2, 0(a0)        #read size from header
    addi a0, a0 ,2
    add a3, a2, a0       #current pos+size=end
@@ -51,9 +50,7 @@ fetch_offset:
    addi a5, a5, 4       #match length is >4 bytes
    jal copy_data
    bge a3, a0, fetch_token #reached end of data?
-   lw ra, 0(sp)
-   addi sp, sp, 16
-   ret
+   jr t0
 
 fetch_length:
    xori a4, a5, 0xf

--- a/lz4depack.asm
+++ b/lz4depack.asm
@@ -20,7 +20,7 @@
 
 depack:
    #in: a0 is source
-   #    s0 is destination
+   #    a1 is destination
    #used: a1,a2,a3,a4,a5,a6 for compliance with C-extension
    
    addi	sp,sp,-16
@@ -36,18 +36,18 @@ fetch_token:
    jal fetch_length
 
    mv a2, a0
-   jal copy_data        #literal copy a2 to s0
+   jal copy_data        #literal copy a2 to a1
    mv a0, a2
 
 fetch_offset:
    lbu s1, 0(a0)        #offset is halfword but at byte alignment
-   sub a2, s0, s1
+   sub a2, a1, s1
    lbu s1, 1(a0)
    addi a0, a0, 2       #placed here for pipeline
    slli s1, s1, 8
    sub a2, a2, s1 
    andi a5, a4, 0x0f    #get offset
-   jal fetch_length 
+   jal fetch_length
    addi a5, a5, 4       #match length is >4 bytes
    jal copy_data
    bge a3, a0, fetch_token #reached end of data?
@@ -56,23 +56,23 @@ fetch_offset:
    ret
 
 fetch_length:
-   xori a1, a5, 0xf
-   bnez a1, _done       #0x0f indicates further bytes
+   xori s1, a5, 0xf
+   bnez s1, _done       #0x0f indicates further bytes
 
 _loop:   
    lbu s1, 0(a0)
    addi a0, a0, 1
    add a5, a5, s1
-   xori a1, s1, 0xff    #0xff indicates further bytes
-   beqz a1, _loop
+   xori s1, s1, 0xff    #0xff indicates further bytes
+   beqz s1, _loop
 _done:
    ret
 
 copy_data:
    lbu a6, 0(a2)
    addi a2, a2, 1       #placed here for pipeline
-   sb a6, 0(s0)
-   addi s0, s0, 1
+   sb a6, 0(a1)
+   addi a1, a1, 1
    addi a5, a5, -1
    bnez a5, copy_data
    ret

--- a/packedearth.asm
+++ b/packedearth.asm
@@ -19,7 +19,7 @@ main:
    
 show_packed_earth:
     li a0, gfx_data
-    li s0, RAM
+    li a1, RAM
     jal depack #depack lz4 compressed data into RAM
     
     li  a5, GPIO_BASE_ADDR_B
@@ -389,7 +389,7 @@ bytes   0 #end of data
 align 2
 #begin_depack:
 #a0 source
-#s0 destination
+#a1 destination
 include lz4depack.asm
 
 gfx_data:


### PR DESCRIPTION
Note: I've just observed that bronzebeard is incorrectly using 4-byte instructions for mv -- unless the src or dst is x0, it is always possible to use the 2-byte c.mv instruction. This is making the program unnecessarily large.

You can check by assembling with gcc instead.

First, make the register defines gcc/gas compatible:

`perl -pe 's/^\s*([a-z_]+)\s*=\s*([a-zA-Z0-9]+)(\s*#.*)?$/#define $1 $2/' lz4depack.asm >lz4depack.S`

Then assemble, using the C preprocessor:

`riscv64-unknown-elf-gcc -march=rv32ic -mabi=ilp32 lz4depack.S -c`

And check the code using riscv64-unknown-elf-size or riscv64-unknown-elf-objdump
